### PR TITLE
Added Links to the Public Calendar and the Dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,8 @@
         <a href="https://github.com/emccode/emccode.github.io/wiki/How-to-contribute-to-EMC-CODE-projects"><li>CONTRIBUTE</li></a>
         <a href="https://github.com/emccode/emccode-newsletter"><li>NEWSLETTERS</li></a>
         <a href="https://github.com/emccode/roadmap"><li>ROADMAP</li></a>
-        <!-- save until it's worth showing <a href="http://dashboard.emccode.com/sample"><li>DASHBOARD</li></a> -->
+        <a href="https://www.google.com/calendar/embed?src=52rlkjj3h1lsfqmi5hr0475ceg%40group.calendar.google.com"><li>CALENDAR</li></a>
+        <a href="http://dashboard.emccode.com/sample"><li>DASHBOARD</li></a>
       </ul>
     </nav>
     <div id="nav-trigger">


### PR DESCRIPTION
Validated in Safari and Firefox in OS X 10.10.5. Do we test in anything else?
