### PR TITLE
Changed the URL for vagrant-mesos

### DIFF
--- a/index.html
+++ b/index.html
@@ -533,7 +533,7 @@
                   </a>
                 </li>
                 <li class="tooltip Github Docker Vagrant Mesos">
-                  <a href="https://github.com/jonasrosland/vagrant-mesos/tree/mesos-rexray">
+                  <a href="https://github.com/jonasrosland/vagrant-mesos/">
                     <div class="item_bg" style="background: url(images/items/mesosdockerrr_black.png) no-repeat center center; background-size: cover;">
                       <h2>vagrant-mesos</h2>
                       <div class="hover_image"></div>


### PR DESCRIPTION
Correct URL for the vagrant-mesos repo now that the changes have been merged into the master branch.

Signed-off-by: jonas.rosland@gmail.com
