### PR TITLE
Small Tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
               <section>
                 <h2 class="center">FEATURED PROJECTS</h2>
                 <ul class="item_box_featured nospace">
-                  <li class="tooltip Github Node.js Read-The-Docs Travis-CI">
+                  <li class="tooltip GitHub Node.js Read-The-Docs Travis-CI">
                     <a href="https://github.com/rackhd/rackhd">
                       <div class="item_bg" style="background: url(images/items/rackhd.png) no-repeat center center; background-size: cover;">
                         <h2>RackHD</h2>
@@ -104,7 +104,7 @@
                       </div>
                     </a>
                   </li>
-                  <li class="tooltip Github Go ScaleIO OpenStack Docker XtremIO EBS AWS EC2 Coveralls Travis-CI Read-The-Docs">
+                  <li class="tooltip GitHub Go ScaleIO OpenStack Docker XtremIO EBS AWS EC2 Coveralls Travis-CI Read-The-Docs">
                     <a href="https://github.com/emccode/rexray">
                       <div class="item_bg" style="background: url(images/items/rexray.png) no-repeat center center; background-size: cover;">
                         <h2>REX-Ray</h2>
@@ -112,7 +112,7 @@
                       </div>
                     </a>
                   </li>
-                  <li class="tooltip Github Docker Mesos C++ Travis-CI">
+                  <li class="tooltip GitHub Docker Mesos C++ Travis-CI">
                     <a href="https://github.com/emccode/mesos-module-dvdi">
                       <div class="item_bg" style="background: url(images/items/mesos-module-dvdi.png) no-repeat center center; background-size: cover;">
                         <h2>mesos-module-dvdi</h2>
@@ -144,7 +144,7 @@
           <section>
             <h3>Infrastructure as Code</h3>
               <ul class="item_box">
-                <li class="tooltip Github Node.js Read-The-Docs Travis-CI">
+                <li class="tooltip GitHub Node.js Read-The-Docs Travis-CI">
                   <a href="https://github.com/rackhd/rackhd">
                     <div class="item_bg" style="background: url(images/items/rackhd.png) no-repeat center center; background-size: cover;">
                       <h2>RackHD</h2>
@@ -152,7 +152,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Go ScaleIO OpenStack Docker XtremIO EBS AWS EC2 Coveralls Travis-CI Read-The-Docs">
+                <li class="tooltip GitHub Go ScaleIO OpenStack Docker XtremIO EBS AWS EC2 Coveralls Travis-CI Read-The-Docs">
                   <a href="https://github.com/emccode/rexray">
                     <div class="item_bg" style="background: url(images/items/rexray.png) no-repeat center center; background-size: cover;">
                       <h2>REX-Ray</h2>
@@ -160,7 +160,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Docker Mesos C++ Travis-CI">
+                <li class="tooltip GitHub Docker Mesos C++ Travis-CI">
                   <a href="https://github.com/emccode/mesos-module-dvdi">
                     <div class="item_bg" style="background: url(images/items/mesos-module-dvdi.png) no-repeat center center; background-size: cover;">
                       <h2>mesos-module-dvdi</h2>
@@ -176,7 +176,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github ScaleIO Flocker Docker VMAX ScaleIO XtremIO">
+                <li class="tooltip GitHub ScaleIO Flocker Docker VMAX ScaleIO XtremIO">
                   <a href="https://github.com/emccode/flocker-drivers">
                     <div class="item_bg" style="background: url(images/items/flocker-drivers.png) no-repeat center center; background-size: cover;">
                       <h2>Flocker Drivers</h2>
@@ -184,7 +184,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Go Isilon SDK">
+                <li class="tooltip GitHub Go Isilon SDK">
                   <a href="https://github.com/emccode/goisilon">
                     <div class="item_bg" style="background: url(images/items/goisilon.png) no-repeat center center; background-size: cover;">
                       <h2>goisilon</h2>
@@ -192,7 +192,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Go VMAX SDK">
+                <li class="tooltip GitHub Go VMAX SDK">
                   <a href="https://github.com/emccode/govmax">
                     <div class="item_bg" style="background: url(images/items/govmax.png) no-repeat center center; background-size: cover;">
                       <h2>govmax</h2>
@@ -200,7 +200,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Go ScaleIO SDK">
+                <li class="tooltip GitHub Go ScaleIO SDK">
                   <a href="https://github.com/emccode/goscaleio">
                     <div class="item_bg" style="background: url(images/items/goscaleio.png) no-repeat center center; background-size: cover;">
                       <h2>goscaleio</h2>
@@ -208,7 +208,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Go XtremIO SDK">
+                <li class="tooltip GitHub Go XtremIO SDK">
                   <a href="https://github.com/emccode/goxtremio">
                     <div class="item_bg" style="background: url(images/items/goxtremio.png) no-repeat center center; background-size: cover;">
                       <h2>goxtremio</h2>
@@ -216,7 +216,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github ViPR SDK Ruby">
+                <li class="tooltip GitHub ViPR SDK Ruby">
                   <a href="https://github.com/emccode/Vipruby">
                     <div class="item_bg" style="background: url(images/items/vipruby.png) no-repeat center center; background-size: cover;">
                       <h2>ViPRuby</h2>
@@ -224,7 +224,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Python ViPR SDK DevHigh5">
+                <li class="tooltip GitHub Python ViPR SDK DevHigh5">
                   <a href="https://github.com/chadlung/viperpy">
                     <div class="item_bg" style="background: url(images/items/viperpy.png) no-repeat center center; background-size: cover;">
                       <h2>ViperPy</h2>
@@ -232,7 +232,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Python ScaleIO REST DevHigh5">
+                <li class="tooltip GitHub Python ScaleIO REST DevHigh5">
                   <a href="https://github.com/swevm/scaleio-py">
                     <div class="item_bg" style="background: url(images/items/scaleio-py.png) no-repeat center center; background-size: cover;">
                       <h2>ScaleIO-py</h2>
@@ -240,7 +240,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Python XtremIO REST DevHigh5">
+                <li class="tooltip GitHub Python XtremIO REST DevHigh5">
                   <a href="https://github.com/nachiketkarmarkar/PyXtrem">
                     <div class="item_bg" style="background: url(images/items/PyXtrem.png) no-repeat center center; background-size: cover;">
                       <h2>PyXtrem</h2>
@@ -248,7 +248,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Mesos Docker Go">
+                <li class="tooltip GitHub Mesos Docker Go">
                   <a href="https://github.com/emccode/dvdcli">
                     <div class="item_bg" style="background: url(images/items/dvdcli.png) no-repeat center center; background-size: cover;">
                       <h2>dvdcli</h2>
@@ -256,7 +256,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Puppet VNX">
+                <li class="tooltip GitHub Puppet VNX">
                   <a href="https://github.com/emccode/puppet-vnx">
                     <div class="item_bg" style="background: url(images/items/puppet-vnx.png) no-repeat center center; background-size: cover;">
                       <h2>puppet-vnx</h2>
@@ -264,7 +264,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github ScaleIO Ansible DevHigh5">
+                <li class="tooltip GitHub ScaleIO Ansible DevHigh5">
                   <a href="https://github.com/sperreault/ansible-scaleio">
                     <div class="item_bg" style="background: url(images/items/ansible-scaleio.png) no-repeat center center; background-size: cover;">
                       <h2>ansible-scaleio</h2>
@@ -272,7 +272,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github XtremIO Powershell DevHigh5">
+                <li class="tooltip GitHub XtremIO Powershell DevHigh5">
                   <a href="https://github.com/bkvarda/xtremlib">
                     <div class="item_bg" style="background: url(images/items/xtremlib.jpg) no-repeat center center; background-size: cover;">
                       <h2>XtremLib</h2>
@@ -280,7 +280,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github XtremIO Snap Python DevHigh5">
+                <li class="tooltip GitHub XtremIO Snap Python DevHigh5">
                   <a href="https://github.com/evanbattle/XtremIOSnap">
                     <div class="item_bg" style="background: url(images/items/xtremiosnap.jpg) no-repeat center center; background-size: cover;">
                       <h2>XtremIOSnap</h2>
@@ -288,7 +288,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Isilon Powershell DevHigh5">
+                <li class="tooltip GitHub Isilon Powershell DevHigh5">
                   <a href="https://github.com/vchrisb/Isilon-POSH">
                     <div class="item_bg" style="background: url(images/items/isilon-posh.png) no-repeat center center; background-size: cover;">
                       <h2>Isilon-POSH</h2>
@@ -296,7 +296,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github ScaleIO Powershell DevHigh5">
+                <li class="tooltip GitHub ScaleIO Powershell DevHigh5">
                   <a href="https://github.com/emccode/SIOToolKit">
                     <div class="item_bg" style="background: url(images/items/SIOToolKit.png) no-repeat center center; background-size: cover;">
                       <h2>SIOToolKit</h2>
@@ -304,7 +304,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Python VMware NSX REST DevHigh5">
+                <li class="tooltip GitHub Python VMware NSX REST DevHigh5">
                   <a href="https://github.com/wallnerryan/nvpnsxapi">
                     <div class="item_bg" style="background: url(images/items/nvpnsxapi.png) no-repeat center center; background-size: cover;">
                       <h2>Nicira NVP/NSX Python</h2>
@@ -312,10 +312,10 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github ECS CloudFoundry Spring Java Object">
+                <li class="tooltip GitHub Travis-CI ECS CloudFoundry Java Object">
                   <a href="https://github.com/emccode/ecs-cf-service-broker">
                     <div class="item_bg" style="background: url(images/items/ecs-cf-service-broker.png) no-repeat center center; background-size: cover;">
-                      <h2>ECS Cloud Foundry Service Broker</h2>
+                      <h2>ECS Service Broker</h2>
                       <div class="hover_image"></div>
                     </div>
                   </a>
@@ -328,7 +328,7 @@
           <section>
             <h3>Tools</h3>
               <ul class="item_box">
-                <li class="tooltip Github Node.js Object REST ViPR ECS">
+                <li class="tooltip GitHub Node.js Object REST ViPR ECS">
                   <a href="https://github.com/kacole2/s3motion">
                     <div class="item_bg" style="background: url(images/items/s3motion.png) no-repeat center center; background-size: cover;">
                       <h2>s3motion</h2>
@@ -336,7 +336,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github REST OpenStack Python Vagrant Angular.js">
+                <li class="tooltip GitHub REST OpenStack Python Vagrant Angular.js">
                   <a href="https://github.com/emccode/HeliosBurn">
                     <div class="item_bg" style="background: url(images/items/heliosburn.png) no-repeat center center; background-size: cover;">
                       <h2>Helios Burn</h2>
@@ -344,7 +344,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github VMAX Docker DevHigh5">
+                <li class="tooltip GitHub VMAX Docker DevHigh5">
                   <a href="https://github.com/seancummins/dockerized_symcli">
                     <div class="item_bg" style="background: url(images/items/dockerized_symcli.jpg) no-repeat center center; background-size: cover;">
                       <h2>Dockerized Symcli</h2>
@@ -352,7 +352,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github REST DevHigh5">
+                <li class="tooltip GitHub REST DevHigh5">
                   <a href="https://github.com/djannot/web-automation-center">
                     <div class="item_bg" style="background: url(images/items/web_automation_center.jpg) no-repeat center center; background-size: cover;">
                       <h2>Web Automation Center</h2>
@@ -360,7 +360,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Python VMAX DevHigh5">
+                <li class="tooltip GitHub Python VMAX DevHigh5">
                   <a href="https://github.com/seancummins/fast_report">
                     <div class="item_bg" style="background: url(images/items/fast_report.jpg) no-repeat center center; background-size: cover;">
                       <h2>FAST Report</h2>
@@ -368,7 +368,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github VNX OpenStack">
+                <li class="tooltip GitHub VNX OpenStack">
                   <a href="https://github.com/emc-openstack/vnx-faulty-device-cleanup">
                     <div class="item_bg" style="background: url(images/items/openstack-vnx.png) no-repeat center center; background-size: cover;">
                       <h2>VNX Device Cleanup</h2>
@@ -376,7 +376,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Docker Snake-Charmer Object">
+                <li class="tooltip GitHub Docker Snake-Charmer Object">
                   <a href="https://github.com/clintonskitson/snake_charmer">
                     <div class="item_bg" style="background: url(images/items/snakecharmer.jpg) no-repeat center center; background-size: cover;">
                       <h2>Snake Charmer</h2>
@@ -384,7 +384,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Ruby ViPR DevHigh5 ECS">
+                <li class="tooltip GitHub Ruby ViPR DevHigh5 ECS">
                   <a href="https://github.com/emcvipr/mnrcli">
                     <div class="item_bg" style="background: url(images/items/mnrcli.png) no-repeat center center; background-size: cover;">
                       <h2>mnrcli</h2>
@@ -392,7 +392,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Python Isilon DevHigh5">
+                <li class="tooltip GitHub Python Isilon DevHigh5">
                   <a href="https://github.com/obergt/Isilon_Tools">
                     <div class="item_bg" style="background: url(images/items/isilon-tools.png) no-repeat center center; background-size: cover;">
                       <h2>Isilon Shares Backup</h2>
@@ -400,7 +400,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Powershell DevHigh5 VMware NSX">
+                <li class="tooltip GitHub Powershell DevHigh5 VMware NSX">
                   <a href="https://github.com/WahlNetwork/nsx-tier-builder">
                     <div class="item_bg" style="background: url(images/items/nsx-tier-builder.png) no-repeat center center; background-size: cover;">
                       <h2>NSX Tier Builder</h2>
@@ -408,7 +408,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github XtremIO DevHigh5 PHP Laravel">
+                <li class="tooltip GitHub XtremIO DevHigh5 PHP Laravel">
                   <a href="https://github.com/shairozan/xsnapcourier">
                     <div class="item_bg" style="background: url(images/items/xsnapcourier.png) no-repeat center center; background-size: cover;">
                       <h2>XSnapCourier</h2>
@@ -416,7 +416,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github VMAX VNX ExtremIO DevHigh5 Java">
+                <li class="tooltip GitHub VMAX VNX ExtremIO DevHigh5 Java">
                   <a href="https://github.com/wmasry/SAN-Commands-Generator">
                     <div class="item_bg" style="background: url(images/items/sancommands.png) no-repeat center center; background-size: cover;">
                       <h2>SAN Command Generator</h2>
@@ -424,7 +424,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github RecoverPoint DevHigh5 Angular.js REST Java">
+                <li class="tooltip GitHub RecoverPoint DevHigh5 Angular.js REST Java">
                   <a href="https://github.com/cunla/qurt">
                     <div class="item_bg" style="background: url(images/items/qurt.png) no-repeat center center; background-size: cover;">
                       <h2>QURT</h2>
@@ -432,7 +432,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Go Docker VMware">
+                <li class="tooltip GitHub Go Docker VMware">
                   <a href="https://github.com/clintonskitson/goair">
                     <div class="item_bg" style="background: url(images/items/goair.png) no-repeat center center; background-size: cover;">
                       <h2>Go-Air</h2>
@@ -440,7 +440,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Python MiTrend REST DevHigh5">
+                <li class="tooltip GitHub Python MiTrend REST DevHigh5">
                   <a href="https://github.com/bbertka/mitrend-python">
                     <div class="item_bg" style="background: url(images/items/mitrend-python.png) no-repeat center center; background-size: cover;">
                       <h2>MiTrend-Python</h2>
@@ -448,7 +448,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Python XtremIO DevHigh5">
+                <li class="tooltip GitHub Python XtremIO DevHigh5">
                   <a href="https://github.com/nachiketkarmarkar/XtremPerfProbe">
                     <div class="item_bg" style="background: url(images/items/XtremPerfProbe.png) no-repeat center center; background-size: cover;">
                       <h2>XtremPerfProbe</h2>
@@ -456,7 +456,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github JavaScript DevHigh5">
+                <li class="tooltip GitHub JavaScript DevHigh5">
                   <a href="https://github.com/ravikiranvs/generator-servicenow-reactjs">
                     <div class="item_bg" style="background: url(images/items/generator-servicenow-reactjs.png) no-repeat center center; background-size: cover;">
                       <h2>servicenow-reactjs</h2>
@@ -464,7 +464,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Python VNX DevHigh5">
+                <li class="tooltip GitHub Python VNX DevHigh5">
                   <a href="https://github.com/ktelep/EMC-Zabbix-Integration">
                     <div class="item_bg" style="background: url(images/items/EMC-Zabbix.png) no-repeat center center; background-size: cover;">
                       <h2>EMC-Zabbix</h2>
@@ -480,7 +480,7 @@
           <section>
             <h3>Applications</h3>
               <ul class="item_box">
-                <li class="tooltip Github REST Object ECS ViPR Python Docker Angular.js">
+                <li class="tooltip GitHub REST Object ECS ViPR Python Docker Angular.js">
                   <a href="https://github.com/emccode/mosaicme">
                     <div class="item_bg" style="background: url(images/items/mosaicme.jpg) no-repeat center center; background-size: cover;">
                       <h2>MosaicMe</h2>
@@ -488,7 +488,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Docker Object REST Python ViPR ECS">
+                <li class="tooltip GitHub Docker Object REST Python ViPR ECS">
                   <a href="https://github.com/clintonskitson/socieidos">
                     <div class="item_bg" style="background: url(images/items/socieidos.jpg) no-repeat center center; background-size: cover;">
                       <h2>Socieidos</h2>
@@ -496,7 +496,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Node.js REST Object ECS ViPR">
+                <li class="tooltip GitHub Node.js REST Object ECS ViPR">
                   <a href="https://github.com/kacole2/photobooth">
                     <div class="item_bg" style="background: url(images/items/photobooth.png) no-repeat center center; background-size: cover;">
                       <h2>Photo Booth</h2>
@@ -512,7 +512,7 @@
           <section>
             <h3>Examples & Samples</h3>
               <ul class="item_box">
-                <li class="tooltip Github Vagrant Puppet ScaleIO">
+                <li class="tooltip GitHub Vagrant Puppet ScaleIO">
                   <a href="https://github.com/clintonskitson/vagrant-puppet-scaleio">
                     <div class="item_bg" style="background: url(images/items/vagrant-puppet-scaleio.jpg) no-repeat center center; background-size: cover;">
                       <h2>vagrant-puppet-scaleio</h2>
@@ -520,7 +520,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Docker Vagrant Mesos">
+                <li class="tooltip GitHub Docker Vagrant Mesos">
                   <a href="https://github.com/jonasrosland/vagrant-mesos/">
                     <div class="item_bg" style="background: url(images/items/mesosdockerrr_black.png) no-repeat center center; background-size: cover;">
                       <h2>vagrant-mesos</h2>
@@ -528,7 +528,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github ScaleIO Docker REST Go Puppet Vagrant">
+                <li class="tooltip GitHub ScaleIO Docker REST Go Puppet Vagrant">
                   <a href="https://github.com/clintonskitson/arrowhead">
                     <div class="item_bg" style="background: url(images/items/arrowhead.jpg) no-repeat center center; background-size: cover;">
                       <h2>Arrowhead</h2>
@@ -536,7 +536,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Docker ECS Object">
+                <li class="tooltip GitHub Docker ECS Object">
                   <a href="https://github.com/emccode/ecs-dockerswarm">
                     <div class="item_bg" style="background: url(images/items/ecs-dockerswarm.png) no-repeat center center; background-size: cover;">
                       <h2>ecs-dockerswarm</h2>
@@ -544,7 +544,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Vagrant ViPR DevHigh5">
+                <li class="tooltip GitHub Vagrant ViPR DevHigh5">
                   <a href="https://github.com/vchrisb/vagrant-coprhd">
                     <div class="item_bg" style="background: url(images/items/vagrant-coprhd.png) no-repeat center center; background-size: cover;">
                       <h2>vagrant-coprhd</h2>
@@ -552,7 +552,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github ScaleIO Vagrant">
+                <li class="tooltip GitHub ScaleIO Vagrant">
                   <a href="https://github.com/virtualswede/vagrant-scaleio">
                     <div class="item_bg" style="background: url(images/items/scaleiovagrant.png) no-repeat center center; background-size: cover;">
                       <h2>vagrant-scaleio</h2>
@@ -560,7 +560,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github ScaleIO Docker DevHigh5">
+                <li class="tooltip GitHub ScaleIO Docker DevHigh5">
                   <a href="https://github.com/djannot/scaleio-docker">
                     <div class="item_bg" style="background: url(images/items/scaleio-docker.png) no-repeat center center; background-size: cover;">
                       <h2>Dockerized ScaleIO</h2>
@@ -568,7 +568,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Core2f Go Docker">
+                <li class="tooltip GitHub Core2f Go Docker">
                   <a href="https://github.com/clintonskitson/core2f">
                     <div class="item_bg" style="background: url(images/items/core2f.png) no-repeat center center; background-size: cover;">
                       <h2>Core2F</h2>
@@ -576,7 +576,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github Vagrant">
+                <li class="tooltip GitHub Vagrant">
                   <a href="https://github.com/clintonskitson/vagrantspice">
                     <div class="item_bg" style="background: url(images/items/vagrantspice.jpg) no-repeat center center; background-size: cover;">
                       <h2>VagrantSpice</h2>
@@ -584,7 +584,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github XtremIO DevHigh5">
+                <li class="tooltip GitHub XtremIO DevHigh5">
                   <a href="https://github.com/nachiketkarmarkar/iCDM4XtremIO">
                     <div class="item_bg" style="background: url(images/items/iCDM4XtremIO.png) no-repeat center center; background-size: cover;">
                       <h2>iCDM4XtremIO</h2>
@@ -600,7 +600,7 @@
           <section>
             <h3>Openstack</h3>
               <ul class="item_box">
-                <li class="tooltip Github ScaleIO OpenStack Fuel">
+                <li class="tooltip GitHub ScaleIO OpenStack Fuel">
                   <a href="https://github.com/openstack/fuel-plugin-scaleio">
                     <div class="item_bg" style="background: url(images/items/fuel-scaleio.png) no-repeat center center; background-size: cover;">
                       <h2>ScaleIO Plugins for Fuel</h2>
@@ -608,7 +608,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github ViPR OpenStack ECS">
+                <li class="tooltip GitHub ViPR OpenStack ECS">
                   <a href="https://github.com/emcvipr/controller-openstack-cinder">
                     <div class="item_bg" style="background: url(images/items/openstack-vipr.png) no-repeat center center; background-size: cover;">
                       <h2>ViPR Cinder Driver</h2>
@@ -616,7 +616,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github VNX OpenStack">
+                <li class="tooltip GitHub VNX OpenStack">
                   <a href="https://github.com/emc-openstack/vnx-direct-driver">
                     <div class="item_bg" style="background: url(images/items/openstack-vnx.png) no-repeat center center; background-size: cover;">
                       <h2>VNX Direct Driver</h2>
@@ -624,7 +624,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github VMAX OpenStack">
+                <li class="tooltip GitHub VMAX OpenStack">
                   <a href="https://github.com/emc-openstack/vmax-cinder-driver">
                     <div class="item_bg" style="background: url(images/items/openstack-vmax.png) no-repeat center center; background-size: cover;">
                       <h2>VMAX Cinder Driver</h2>
@@ -632,7 +632,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github XtremIO OpenStack">
+                <li class="tooltip GitHub XtremIO OpenStack">
                   <a href="https://github.com/emc-openstack/xtremio-cinder-driver">
                     <div class="item_bg" style="background: url(images/items/openstack-xtremio.png) no-repeat center center; background-size: cover;">
                       <h2>XtremIO Cinder Driver</h2>
@@ -640,7 +640,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github SMI-S OpenStack">
+                <li class="tooltip GitHub SMI-S OpenStack">
                   <a href="https://github.com/emc-openstack/smis-fc-cinder-driver">
                     <div class="item_bg" style="background: url(images/items/openstack-smis.png) no-repeat center center; background-size: cover;">
                       <h2>SMI-S FC Cinder Driver</h2>
@@ -648,7 +648,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github SMI-S OpenStack">
+                <li class="tooltip GitHub SMI-S OpenStack">
                   <a href="https://github.com/emc-openstack/smis-iscsi-cinder-driver">
                     <div class="item_bg" style="background: url(images/items/openstack-smis.png) no-repeat center center; background-size: cover;">
                       <h2>SMI-S iSCSI Cinder Dri...</h2>
@@ -656,7 +656,7 @@
                     </div>
                   </a>
                 </li>
-                <li class="tooltip Github VNXe OpenStack">
+                <li class="tooltip GitHub VNXe OpenStack">
                   <a href="https://github.com/emc-openstack/vnxe-cinder-driver">
                     <div class="item_bg" style="background: url(images/items/openstack-vnxe.png) no-repeat center center; background-size: cover;">
                       <h2>VNXe Cinder Driver</h2>
@@ -675,11 +675,11 @@
         <h4>focus communities</h4>
           <a href="#" class="btnf">Docker</a>
           <a href="#" class="btnf">Mesos</a>
-          <a href="#" class="btnf">Github</a>
-          <a href="#" class="btnf">Slack</a>
           <a href="#" class="btnf">Travis-CI</a>
-          <a href="#" class="btnf">Coveralls</a>
-          <a href="#" class="btnf">Read-The-Docs</a>
+         <!-- Don't think it is <a href="#" class="btnf">Coveralls</a> 
+          <a href="#" class="btnf">Read-The-Docs</a> 
+          <a href="#" class="btnf">Slack</a> 
+          <a href="#" class="btnf">GitHub</a> -->
           <a href="#" class="btnf">DevHigh5</a>
 
         <h4>tags</h4>
@@ -695,6 +695,7 @@
           <a href="#" class="btn">NSX</a>
           <a href="#" class="btn">OpenStack</a>
           <a href="#" class="btn">VMware</a>
+          <a href="#" class="btn">CloudFoundry</a>
           <a href="#" class="btn">Puppet</a>
           <a href="#" class="btn">Vagrant</a>
           <a href="#" class="btn">Ansible</a>
@@ -709,8 +710,6 @@
           <a href="#" class="btn">Object</a>
           <a href="#" class="btn">REST</a>
           <a href="#" class="btn">SDK</a>
-          <a href="#" class="btn">Spring</a>
-          <a href="#" class="btn">CloudFoundry</a>
 
           <!-- Removing Clear Tag for a while
           <a href="#">
@@ -721,27 +720,17 @@
           -->
         <h4>join our community</h4>
           <ul style="list-style-type: none;">
-            <li style="margin: 2px 0 0 0;"><a href="https://github.com/orgs/emccode/people"><img src="images/github19.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">members</span><span class="badge badgeGithubRight" id="publicMemberCount"></span></a></li>
+            <li style="margin: 2px 0 0 0;"><a href="https://github.com/orgs/emccode/people"><img src="images/github19.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">members</span><span class="badge badgeGitHubRight" id="publicMemberCount"></span></a></li>
             <li style="margin: 2px 0 0 0;"><a href="http://twitter.com/emccode"><img src="images/twitter39.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">followers</span><span class="badge badgeTwitterRight" id="twitterFollowerCount"></span></a></li>
             <li style="margin: 2px 0 0 0;"><a href="http://visitor.r20.constantcontact.com/d.jsp?llr=qipf4rsab&p=oi&m=1119442091280&sit=7hqmx8ijb&f=928bf5a1-912d-4bcd-bcf4-422e2f9acb40"><img src="images/newsletter.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">subscribers</span><span class="badge badgeNewsletterRight" id="newsletterSubscriberCount"></span></a> <a href="https://github.com/emccode/emccode-newsletter">[archive]</a></li>
-            <!--<li style="margin: 2px 0 0 0;"><a href="https://groups.google.com/forum/#!categories/emccode-users"><img src="images/googlegroup.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">google group</span><span class="badge badgeGoogleGroupRight"> #emccode-users</span></a></li>-->
             <li style="margin: 2px 0 0 0;"><a href="http://community.emccode.com"><img src="images/slack.png" style="width: 20px;" align="top"> <img src="http://community.emccode.com/badge.svg"></a></li>
           </ul>
         <h4>faq</h4>
           <ul>
-            <li><a href="http://stackoverflow.com/questions/tagged/emc">'emc' on Stack Overflow</a></li>
-            <!--<li><a href="http://webchat.freenode.net/">#emccode on Freenode</a></li>
-            <li><a href="https://groups.google.com/forum/#!forum/emccode-users">#emccode-users on Google Groups</a></li>-->
             <li><a href="https://github.com/emccode/emccode.github.io/wiki/DevHigh5-Program-Overview-and-FAQ">DevHigh5 Program Overview</a></li>
             <li><a href="https://github.com/emccode/emccode.github.io/wiki/EMC-CODE-Governance,-Contributing,-and-Code-of-Conduct">Governance, Contributing, and Code of Conduct</a></li>
             <li><a href="https://www.emc.com/careers/index.htm">join us! | careers at EMC</a></li>
           </ul>
-        <!--
-        <h4>keep in touch</h4>
-          <ul>
-            <li><a href="https://www.emc.com/careers/index.htm">join us! | careers at EMC</a></li>
-          </ul>
-        -->
       </div>
 
     </div>


### PR DESCRIPTION
This commit fixed a bunch of a small issues. Renamed tags with Github to GitHub. Removed Focus Communities of GitHub, Coveralls, ReadTheDocs, and Slack. This is repeated because there is a section within the stick that says 'Join our community' that has both Slack and GitHub links. Updated ECS Service Broker for CF titles and edited the tags associated with it. Removed the Spring tag that was from a prior commit. Removed a bunch of old code that had been commented out for a long time and was never going to make it back in.

Signed-off-by: Kendrick Coleman kendrickcoleman@gmail.com
