### PR TITLE
Add protocol-independent absolute paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,12 +24,12 @@
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <link rel="stylesheet" type="text/css" href="stylesheets/normalize.css" media="screen">
-    <link href='http://fonts.googleapis.com/css?family=Exo:400,500,700|Quattrocento+Sans:400,400italic|Open+Sans' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Exo:400,500,700|Quattrocento+Sans:400,400italic|Open+Sans' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="stylesheets/stylesheet.css" media="screen">
     <link rel="stylesheet" type="text/css" href="stylesheets/responsive.css" media="screen">
     <link rel="stylesheet" type="text/css" href="stylesheets/tooltipster.css" media="screen">
     <link rel="stylesheet" type="text/css" href="stylesheets/print.css" media="print">
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
     <script src="javascripts/jquery.sticky.js"></script>
     <script src="javascripts/jquery.tooltipster.min.js"></script>
     <script src="javascripts/main.js"></script>
@@ -68,12 +68,12 @@
     <nav id="nav-main">
       <ul>
         <a href="https://github.com/emccode"><li><img src="images/blacktocat.png" style="width: 20px; margin-bottom: -3px;"></li></a>
-        <a href="http://blog.emccode.com"><li>BLOG</li></a>
+        <a href="//blog.emccode.com"><li>BLOG</li></a>
         <a href="https://github.com/emccode/emccode.github.io/wiki/How-to-contribute-to-EMC-CODE-projects"><li>CONTRIBUTE</li></a>
         <a href="https://emccode.github.io/newsletter/"><li>NEWSLETTER</li></a>
         <a href="https://www.google.com/calendar/embed?src=52rlkjj3h1lsfqmi5hr0475ceg%40group.calendar.google.com"><li>CALENDAR</li></a>
         <a href="https://github.com/emccode/roadmap"><li>ROADMAP</li></a>
-        <a href="http://dashboard.emccode.com/stats"><li>DASHBOARD</li></a>
+        <a href="//dashboard.emccode.com/stats"><li>DASHBOARD</li></a>
       </ul>
     </nav>
     <div id="nav-trigger">
@@ -169,7 +169,7 @@
                   </a>
                 </li>
                 <li class="ViPR OpenStack Java">
-                  <a href="http://coprhd.github.io/">
+                  <a href="//coprhd.github.io/">
                     <div class="item_bg" style="background: url(images/items/coprhd_grey.png) no-repeat center center; background-size: cover;">
                       <h2>CoprHD</h2>
                       <div class="hover_image"></div>
@@ -676,9 +676,9 @@
           <a href="#" class="btnf">Docker</a>
           <a href="#" class="btnf">Mesos</a>
           <a href="#" class="btnf">Travis-CI</a>
-         <!-- Don't think it is <a href="#" class="btnf">Coveralls</a> 
-          <a href="#" class="btnf">Read-The-Docs</a> 
-          <a href="#" class="btnf">Slack</a> 
+         <!-- Don't think it is <a href="#" class="btnf">Coveralls</a>
+          <a href="#" class="btnf">Read-The-Docs</a>
+          <a href="#" class="btnf">Slack</a>
           <a href="#" class="btnf">GitHub</a> -->
           <a href="#" class="btnf">DevHigh5</a>
 
@@ -721,9 +721,9 @@
         <h4>join our community</h4>
           <ul style="list-style-type: none;">
             <li style="margin: 2px 0 0 0;"><a href="https://github.com/orgs/emccode/people"><img src="images/github19.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">members</span><span class="badge badgeGithubRight" id="publicMemberCount"></span></a></li>
-            <li style="margin: 2px 0 0 0;"><a href="http://twitter.com/emccode"><img src="images/twitter39.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">followers</span><span class="badge badgeTwitterRight" id="twitterFollowerCount"></span></a></li>
-            <li style="margin: 2px 0 0 0;"><a href="http://visitor.r20.constantcontact.com/d.jsp?llr=qipf4rsab&p=oi&m=1119442091280&sit=7hqmx8ijb&f=928bf5a1-912d-4bcd-bcf4-422e2f9acb40"><img src="images/newsletter.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">subscribers</span><span class="badge badgeNewsletterRight" id="newsletterSubscriberCount"></span></a> <a href="https://github.com/emccode/emccode-newsletter">[archive]</a></li>
-            <li style="margin: 2px 0 0 0;"><a href="http://community.emccode.com"><img src="images/slack.png" style="width: 20px;" align="top"> <img src="http://community.emccode.com/badge.svg"></a></li>
+            <li style="margin: 2px 0 0 0;"><a href="//twitter.com/emccode"><img src="images/twitter39.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">followers</span><span class="badge badgeTwitterRight" id="twitterFollowerCount"></span></a></li>
+            <li style="margin: 2px 0 0 0;"><a href="//visitor.r20.constantcontact.com/d.jsp?llr=qipf4rsab&p=oi&m=1119442091280&sit=7hqmx8ijb&f=928bf5a1-912d-4bcd-bcf4-422e2f9acb40"><img src="images/newsletter.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">subscribers</span><span class="badge badgeNewsletterRight" id="newsletterSubscriberCount"></span></a> <a href="https://github.com/emccode/emccode-newsletter">[archive]</a></li>
+            <li style="margin: 2px 0 0 0;"><a href="//community.emccode.com"><img src="images/slack.png" style="width: 20px;" align="top"> <img src="//community.emccode.com/badge.svg"></a></li>
           </ul>
         <h4>faq</h4>
           <ul>
@@ -737,7 +737,7 @@
 
     <div id="footer">
         <p>&copy; 2016 EMC Corporation, All rights reserved.</p>
-        <p><a href="http://www.emc.com/legal/emc-corporation-privacy-statement.htm">Privacy Policy</a></p>
+        <p><a href="//www.emc.com/legal/emc-corporation-privacy-statement.htm">Privacy Policy</a></p>
     </div>
 
   </body>

--- a/isilon.html
+++ b/isilon.html
@@ -24,12 +24,12 @@
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <link rel="stylesheet" type="text/css" href="stylesheets/normalize.css" media="screen">
-    <link href='http://fonts.googleapis.com/css?family=Exo:400,500,700|Quattrocento+Sans:400,400italic|Open+Sans' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Exo:400,500,700|Quattrocento+Sans:400,400italic|Open+Sans' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="stylesheets/stylesheet.css" media="screen">
     <link rel="stylesheet" type="text/css" href="stylesheets/responsive.css" media="screen">
     <link rel="stylesheet" type="text/css" href="stylesheets/tooltipster.css" media="screen">
     <link rel="stylesheet" type="text/css" href="stylesheets/print.css" media="print">
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
     <script src="javascripts/jquery.sticky.js"></script>
     <script src="javascripts/jquery.tooltipster.min.js"></script>
     <script src="javascripts/main.js"></script>
@@ -57,7 +57,7 @@
     <header>
       <div class="inner">
         <div id="bannerImage">
-          <a href="http://emccode.github.io/"><img src="images/badge.png"></a>
+          <a href="//emccode.github.io/"><img src="images/badge.png"></a>
         </div>
         <div id="bannerText">
           <h1 class="center nospace">EMC {code}</h1>
@@ -189,7 +189,7 @@
           <section>
             <h3>Examples & Samples</h3>
               <ul class="item_box">
-                
+
               </ul>
           </section>
         </div>
@@ -198,7 +198,7 @@
           <section>
             <h3>Openstack</h3>
               <ul class="item_box">
-                
+
               </ul>
           </section>
         </div>
@@ -219,9 +219,9 @@
         <h4>join our community</h4>
           <ul style="list-style-type: none;">
             <li style="margin: 2px 0 0 0;"><a href="https://github.com/orgs/emccode/people"><img src="images/github19.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">members</span><span class="badge badgeGithubRight" id="publicMemberCount"></span></a></li>
-            <li style="margin: 2px 0 0 0;"><a href="http://twitter.com/emccode"><img src="images/twitter39.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">followers</span><span class="badge badgeTwitterRight" id="twitterFollowerCount"></span></a></li>
-            <li style="margin: 2px 0 0 0;"><a href="http://visitor.r20.constantcontact.com/d.jsp?llr=qipf4rsab&p=oi&m=1119442091280&sit=7hqmx8ijb&f=928bf5a1-912d-4bcd-bcf4-422e2f9acb40"><img src="images/newsletter.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">subscribers</span><span class="badge badgeNewsletterRight" id="newsletterSubscriberCount"></span></a> <a href="https://github.com/emccode/emccode-newsletter">[archive]</a></li>
-            <li style="margin: 2px 0 0 0;"><a href="http://community.emccode.com"><img src="images/slack.png" style="width: 20px;" align="top"> <img src="http://community.emccode.com/badge.svg"></a></li>
+            <li style="margin: 2px 0 0 0;"><a href="//twitter.com/emccode"><img src="images/twitter39.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">followers</span><span class="badge badgeTwitterRight" id="twitterFollowerCount"></span></a></li>
+            <li style="margin: 2px 0 0 0;"><a href="//visitor.r20.constantcontact.com/d.jsp?llr=qipf4rsab&p=oi&m=1119442091280&sit=7hqmx8ijb&f=928bf5a1-912d-4bcd-bcf4-422e2f9acb40"><img src="images/newsletter.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">subscribers</span><span class="badge badgeNewsletterRight" id="newsletterSubscriberCount"></span></a> <a href="https://github.com/emccode/emccode-newsletter">[archive]</a></li>
+            <li style="margin: 2px 0 0 0;"><a href="//community.emccode.com"><img src="images/slack.png" style="width: 20px;" align="top"> <img src="//community.emccode.com/badge.svg"></a></li>
           </ul>
         <h4>faq</h4>
           <ul>
@@ -235,7 +235,7 @@
 
     <div id="footer">
         <p>&copy; 2016 EMC Corporation, All rights reserved.</p>
-        <p><a href="http://www.emc.com/legal/emc-corporation-privacy-statement.htm">Privacy Policy</a></p>
+        <p><a href="//www.emc.com/legal/emc-corporation-privacy-statement.htm">Privacy Policy</a></p>
     </div>
 
   </body>

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -146,13 +146,13 @@ $( document ).ready(function() {
     }
 
     function twitterFollows(){
-      $.getJSON( "http://dashboard.emccode.com/widgets/twitter_user_followers.json", function( data ) {
+      $.getJSON( "//dashboard.emccode.com/widgets/twitter_user_followers.json", function( data ) {
         $("#twitterFollowerCount").text(data.current);
       });
     }
 
     function newsletterSubscribers(){
-      $.getJSON( "http://dashboard.emccode.com/widgets/constant_contact_subscribers.json", function( data ) {
+      $.getJSON( "//dashboard.emccode.com/widgets/constant_contact_subscribers.json", function( data ) {
         $("#newsletterSubscriberCount").text(data.current);
       });
     }

--- a/scaleio.html
+++ b/scaleio.html
@@ -24,12 +24,12 @@
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <link rel="stylesheet" type="text/css" href="stylesheets/normalize.css" media="screen">
-    <link href='http://fonts.googleapis.com/css?family=Exo:400,500,700|Quattrocento+Sans:400,400italic|Open+Sans' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Exo:400,500,700|Quattrocento+Sans:400,400italic|Open+Sans' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="stylesheets/stylesheet.css" media="screen">
     <link rel="stylesheet" type="text/css" href="stylesheets/responsive.css" media="screen">
     <link rel="stylesheet" type="text/css" href="stylesheets/tooltipster.css" media="screen">
     <link rel="stylesheet" type="text/css" href="stylesheets/print.css" media="print">
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
     <script src="javascripts/jquery.sticky.js"></script>
     <script src="javascripts/jquery.tooltipster.min.js"></script>
     <script src="javascripts/main.js"></script>
@@ -57,7 +57,7 @@
     <header>
       <div class="inner">
         <div id="bannerImage">
-          <a href="http://emccode.github.io/"><img src="images/badge.png"></a>
+          <a href="//emccode.github.io/"><img src="images/badge.png"></a>
         </div>
         <div id="bannerText">
           <h1 class="center nospace">EMC {code}</h1>
@@ -191,7 +191,7 @@
           <section>
             <h3>Tools</h3>
               <ul class="item_box">
-                
+
               </ul>
           </section>
         </div>
@@ -268,9 +268,9 @@
         <h4>join our community</h4>
           <ul style="list-style-type: none;">
             <li style="margin: 2px 0 0 0;"><a href="https://github.com/orgs/emccode/people"><img src="images/github19.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">members</span><span class="badge badgeGithubRight" id="publicMemberCount"></span></a></li>
-            <li style="margin: 2px 0 0 0;"><a href="http://twitter.com/emccode"><img src="images/twitter39.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">followers</span><span class="badge badgeTwitterRight" id="twitterFollowerCount"></span></a></li>
-            <li style="margin: 2px 0 0 0;"><a href="http://visitor.r20.constantcontact.com/d.jsp?llr=qipf4rsab&p=oi&m=1119442091280&sit=7hqmx8ijb&f=928bf5a1-912d-4bcd-bcf4-422e2f9acb40"><img src="images/newsletter.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">subscribers</span><span class="badge badgeNewsletterRight" id="newsletterSubscriberCount"></span></a> <a href="https://github.com/emccode/emccode-newsletter">[archive]</a></li>
-            <li style="margin: 2px 0 0 0;"><a href="http://community.emccode.com"><img src="images/slack.png" style="width: 20px;" align="top"> <img src="http://community.emccode.com/badge.svg"></a></li>
+            <li style="margin: 2px 0 0 0;"><a href="//twitter.com/emccode"><img src="images/twitter39.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">followers</span><span class="badge badgeTwitterRight" id="twitterFollowerCount"></span></a></li>
+            <li style="margin: 2px 0 0 0;"><a href="//visitor.r20.constantcontact.com/d.jsp?llr=qipf4rsab&p=oi&m=1119442091280&sit=7hqmx8ijb&f=928bf5a1-912d-4bcd-bcf4-422e2f9acb40"><img src="images/newsletter.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">subscribers</span><span class="badge badgeNewsletterRight" id="newsletterSubscriberCount"></span></a> <a href="https://github.com/emccode/emccode-newsletter">[archive]</a></li>
+            <li style="margin: 2px 0 0 0;"><a href="//community.emccode.com"><img src="images/slack.png" style="width: 20px;" align="top"> <img src="//community.emccode.com/badge.svg"></a></li>
           </ul>
         <h4>faq</h4>
           <ul>
@@ -284,7 +284,7 @@
 
     <div id="footer">
         <p>&copy; 2016 EMC Corporation, All rights reserved.</p>
-        <p><a href="http://www.emc.com/legal/emc-corporation-privacy-statement.htm">Privacy Policy</a></p>
+        <p><a href="//www.emc.com/legal/emc-corporation-privacy-statement.htm">Privacy Policy</a></p>
     </div>
 
   </body>

--- a/xtremio.html
+++ b/xtremio.html
@@ -24,12 +24,12 @@
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <link rel="stylesheet" type="text/css" href="stylesheets/normalize.css" media="screen">
-    <link href='http://fonts.googleapis.com/css?family=Exo:400,500,700|Quattrocento+Sans:400,400italic|Open+Sans' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Exo:400,500,700|Quattrocento+Sans:400,400italic|Open+Sans' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="stylesheets/stylesheet.css" media="screen">
     <link rel="stylesheet" type="text/css" href="stylesheets/responsive.css" media="screen">
     <link rel="stylesheet" type="text/css" href="stylesheets/tooltipster.css" media="screen">
     <link rel="stylesheet" type="text/css" href="stylesheets/print.css" media="print">
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
     <script src="javascripts/jquery.sticky.js"></script>
     <script src="javascripts/jquery.tooltipster.min.js"></script>
     <script src="javascripts/main.js"></script>
@@ -57,7 +57,7 @@
     <header>
       <div class="inner">
         <div id="bannerImage">
-          <a href="http://emccode.github.io/"><img src="images/badge.png"></a>
+          <a href="//emccode.github.io/"><img src="images/badge.png"></a>
         </div>
         <div id="bannerText">
           <h1 class="center nospace">EMC {code}</h1>
@@ -68,7 +68,7 @@
     <nav id="nav-main">
       <ul>
         <a href="https://github.com/emccode"><li><img src="images/blacktocat.png" style="width: 20px; margin-bottom: -3px;"></li></a>
-        <a href="http://xtremioblog.emc.com/"><li>XtremIO BLOG</li></a>
+        <a href="//xtremioblog.emc.com/"><li>XtremIO BLOG</li></a>
         <a href="https://github.com/emccode/emccode.github.io/wiki/How-to-contribute-to-EMC-CODE-projects"><li>CONTRIBUTE</li></a>
       </ul>
     </nav>
@@ -271,9 +271,9 @@
         <h4>join our community</h4>
           <ul style="list-style-type: none;">
             <li style="margin: 2px 0 0 0;"><a href="https://github.com/orgs/emccode/people"><img src="images/github19.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">members</span><span class="badge badgeGithubRight" id="publicMemberCount"></span></a></li>
-            <li style="margin: 2px 0 0 0;"><a href="http://twitter.com/emccode"><img src="images/twitter39.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">followers</span><span class="badge badgeTwitterRight" id="twitterFollowerCount"></span></a></li>
-            <li style="margin: 2px 0 0 0;"><a href="http://visitor.r20.constantcontact.com/d.jsp?llr=qipf4rsab&p=oi&m=1119442091280&sit=7hqmx8ijb&f=928bf5a1-912d-4bcd-bcf4-422e2f9acb40"><img src="images/newsletter.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">subscribers</span><span class="badge badgeNewsletterRight" id="newsletterSubscriberCount"></span></a> <a href="https://github.com/emccode/emccode-newsletter">[archive]</a></li>
-            <li style="margin: 2px 0 0 0;"><a href="http://community.emccode.com"><img src="images/slack.png" style="width: 20px;" align="top"> <img src="http://community.emccode.com/badge.svg"></a></li>
+            <li style="margin: 2px 0 0 0;"><a href="//twitter.com/emccode"><img src="images/twitter39.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">followers</span><span class="badge badgeTwitterRight" id="twitterFollowerCount"></span></a></li>
+            <li style="margin: 2px 0 0 0;"><a href="//visitor.r20.constantcontact.com/d.jsp?llr=qipf4rsab&p=oi&m=1119442091280&sit=7hqmx8ijb&f=928bf5a1-912d-4bcd-bcf4-422e2f9acb40"><img src="images/newsletter.png" style="width: 20px;" align="top"> <span class="badge badgeLeft">subscribers</span><span class="badge badgeNewsletterRight" id="newsletterSubscriberCount"></span></a> <a href="https://github.com/emccode/emccode-newsletter">[archive]</a></li>
+            <li style="margin: 2px 0 0 0;"><a href="//community.emccode.com"><img src="images/slack.png" style="width: 20px;" align="top"> <img src="//community.emccode.com/badge.svg"></a></li>
           </ul>
         <h4>faq</h4>
           <ul>
@@ -287,7 +287,7 @@
 
     <div id="footer">
         <p>&copy; 2016 EMC Corporation, All rights reserved.</p>
-        <p><a href="http://www.emc.com/legal/emc-corporation-privacy-statement.htm">Privacy Policy</a></p>
+        <p><a href="//www.emc.com/legal/emc-corporation-privacy-statement.htm">Privacy Policy</a></p>
     </div>
 
   </body>


### PR DESCRIPTION
Enable protocol-independent absolute paths `//` instead of forcing `http`.
This will make it work better when using https://emccode.com.
