### PR TITLE
Remove ScaleIOFrame Tiles from Featured

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,14 +137,6 @@
                       </div>
                     </a>
                   </li>
-                  <li class="tooltip GitHub Docker Mesos C++ Travis-CI">
-                    <a href="https://github.com/codedellemc/scaleio-framework">
-                      <div class="item_bg" style="background: url(images/items/scaleio-framework.jpg) no-repeat center center; background-size: cover;">
-                        <h2>ScaleIO Framework</h2>
-                        <div class="hover_image"></div>
-                      </div>
-                    </a>
-                  </li>
                 </ul>
               </section>
             </div>


### PR DESCRIPTION
removed the ScaleIOFramework tile from the featured projects since there were too many

Signed-off-by: Kendrick Coleman <kendrickcoleman@gmail.com>